### PR TITLE
improve compatibility with luarocks build and install process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ OUTFILE=gd.so
 
 CFLAGS=-O3 -Wall -fPIC $(OMITFP)
 CFLAGS+=`$(GDLIBCONFIG) --cflags` `pkg-config $(LUAPKG) --cflags`
+CFLAGS+=-I$(LUA_INCDIR)
 CFLAGS+=-DVERSION=\"$(VERSION)\"
 
 GDFEATURES=`$(GDLIBCONFIG) --features |sed -e "s/GD_/-DGD_/g"`

--- a/luagd-2.0.33r3-1.rockspec
+++ b/luagd-2.0.33r3-1.rockspec
@@ -33,8 +33,13 @@ build = {
     type = "make",
     platforms = {
         unix = {
+            build_variables = {
+              LUA_INCDIR="$(LUA_INCDIR)",
+              LUABIN = "$(LUA)" },
+            install_variables = {
+              INSTALL_PATH="$(LIBDIR)" },
             build_pass = true,
-            install_pass = false,
+            install_pass = true,
             install = { lib = { "gd.so" } },
             copy_directories = { "doc", "demos" }
         }


### PR DESCRIPTION
With this patch some information is taken from the luarocks
environment for the build and install process
- lua binary (lua, lua5.1, luajit ...)
- lua include path
- library install path

This should solve issue #4. 
