### PR TITLE
Protect declaration of LgdImageCreateFromPng* with GD_PNG feature test macro

### DIFF
--- a/luagd.c
+++ b/luagd.c
@@ -2168,8 +2168,10 @@ static const luaL_Reg LgdFunctions[] =
     { "createFromGif",          LgdImageCreateFromGif },
     { "createFromGifStr",       LgdImageCreateFromGifPtr },
 #endif
+#ifdef GD_PNG
     { "createFromPng",          LgdImageCreateFromPng },
     { "createFromPngStr",       LgdImageCreateFromPngPtr },
+#endif
     { "createFromGd",           LgdImageCreateFromGd },
     { "createFromGdStr",        LgdImageCreateFromGdPtr },
     { "createFromGd2",          LgdImageCreateFromGd2 },


### PR DESCRIPTION
If GD_PNG is false, neither LgdImageCreateFromPng nor
LgdImageCreateFromPngPtr would be implemented.
See the implementation in https://github.com/ittner/lua-gd/blob/master/luagd.c#L417
We should avoid declaring them too.