### PR TITLE
Modified Makefile to only use pkg-config, as gdlib-config no longer exists.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,43 +31,37 @@ VERSION=2.0.33r3
 # Command used to run Lua code
 LUABIN=lua5.1
 
-# Path to the utility 'gdlib-config'. This may be changed to compile the
-# module with development versions of libgd.
-GDLIBCONFIG=gdlib-config
-
 # Optimization for the brave of heart ;)
 OMITFP=-fomit-frame-pointer
 
 
 # ---------------------------------------------------------------------------
-# Automatic configuration using pkgconfig, gd-config and sed. These
-# lines should work on most Linux/Unix systems. If your system does not
-# have these programs you must comment out these lines and uncomment and
-# change the next ones.
+# Automatic configuration using pkgconfig. These lines should work on most
+# Linux/Unix systems. If your system does not have these programs you must
+# comment out these lines and uncomment and change the next ones.
 
 # Name of .pc file. "lua5.1" on Debian/Ubuntu
 LUAPKG=lua5.1
 OUTFILE=gd.so
 
 CFLAGS=-O3 -Wall -fPIC $(OMITFP)
-CFLAGS+=`$(GDLIBCONFIG) --cflags` `pkg-config $(LUAPKG) --cflags`
+CFLAGS+=`pkg-config $(LUAPKG) --cflags`
 CFLAGS+=-DVERSION=\"$(VERSION)\"
 
-GDFEATURES=`$(GDLIBCONFIG) --features |sed -e "s/GD_/-DGD_/g"`
-LFLAGS=-shared `$(GDLIBCONFIG) --ldflags` `$(GDLIBCONFIG) --libs` -lgd
+GDFEATURES=-DGD_XPM -DGD_JPEG -DGD_FONTCONFIG -DGD_FREETYPE -DGD_PNG -DGD_GIF
+LFLAGS=-shared `pkg-config $(LUAPKG) --libs` -lgd
 
-INSTALL_PATH := `$(LUABIN) -e'                          \
-    for dir in package.cpath:gmatch("(/[^?;]+)?") do    \
-        io.write(dir)                                   \
-        os.exit(0)                                      \
-    end                                                 \
-    os.exit(1)                                          \
-'`
-
+INSTALL_PATH := `pkg-config $(LUAPKG) --variable=INSTALL_CMOD`
 
 
 # ---------------------------------------------------------------------------
 # Manual configuration for systems without pkgconfig.
+# WARNING: These instructions will only work on older versions of GD, since
+# gdlib-config has been removed in favor of pkg-config.
+
+# Path to the utility 'gdlib-config'. This may be changed to compile the
+# module with development versions of libgd.
+#GDLIBCONFIG=gdlib-config
 
 #OUTFILE=gd.so
 #CFLAGS=-O3 -Wall -fPIC $(OMITFP)


### PR DESCRIPTION
Only modified the "Automatic configuration" section, but added a warning to the next manual configuration section since that still requires gdlib-config.

Sadly it doesn't seem possible to retrieve the list of GD features anymore, so I set GDFEATURES to a static list.