### PR TITLE
stringFT: Return error message as a second return value

### DIFF
--- a/luagd.c
+++ b/luagd.c
@@ -1888,7 +1888,8 @@ static int LgdImageStringFT(lua_State *L) {
     else
         im = getImagePtr(L, 1);
 
-    if (gdImageStringFT(im, brect, fg, font, size, ang, x, y, str) == NULL) {
+    const char *error_message = gdImageStringFT(im, brect, fg, font, size, ang, x, y, str);
+    if (error_message == NULL) {
         lua_pushnumber(L, brect[0]);
         lua_pushnumber(L, brect[1]);
         lua_pushnumber(L, brect[2]);
@@ -1901,7 +1902,8 @@ static int LgdImageStringFT(lua_State *L) {
     }
 
     lua_pushnil(L);
-    return 1;
+    lua_pushstring(L, error_message);
+    return 2;
 }
 
 


### PR DESCRIPTION
If stringFT() fails, return the error message from gdImageStringFT(), which is useful to diagnose and fix the problem.

There are more functions where this would be helpful, but this one was the only one where we had problems today.